### PR TITLE
Fix xul deprecation

### DIFF
--- a/css/common-files/library.css
+++ b/css/common-files/library.css
@@ -1,4 +1,4 @@
-@-moz-document url(chrome://browser/content/places/places.xul) {
+@-moz-document url(chrome://browser/content/places/places.xhtml) {
   toolbar {
     -moz-appearance: none!important;
     background-color: var(--in-content-category-header-background)!important;

--- a/css/common-files/trees.css
+++ b/css/common-files/trees.css
@@ -1,9 +1,9 @@
 @-moz-document url-prefix(about:),
 url-prefix(chrome://browser/content/preferences/),
-url(chrome://passwordmgr/content/passwordManager.xul),
+url(chrome://passwordmgr/content/passwordManager.xhtml),
 url(chrome://formautofill/content/manageAddresses.xhtml),
 url-prefix(chrome://pippki),
-url(chrome://browser/content/pageinfo/pageInfo.xul) {
+url(chrome://browser/content/pageinfo/pageInfo.xhtml) {
   ::-moz-tree-row(selected) {
     -moz-appearance: none!important;
     background-color: red!important

--- a/css/userChrome-files/common_dialog.css
+++ b/css/userChrome-files/common_dialog.css
@@ -1,4 +1,4 @@
-@-moz-document url("chrome://global/content/commonDialog.xul") {
+@-moz-document url("chrome://global/content/commonDialog.xhtml") {
   #commonDialog {
     -moz-appearance: none!important;
     background: var(--in-content-page-background)!important;

--- a/css/userChrome-files/page_info.css
+++ b/css/userChrome-files/page_info.css
@@ -1,4 +1,4 @@
-@-moz-document url(chrome://browser/content/pageinfo/pageInfo.xul) {
+@-moz-document url(chrome://browser/content/pageinfo/pageInfo.xhtml) {
   #topBar {
     -moz-appearance: none!important;
     background: var(--in-content-category-header-background)!important
@@ -130,7 +130,7 @@
     }
   }
 }
-@-moz-document url-prefix(chrome://browser/content/preferences/cookies.xul) {
+@-moz-document url-prefix(chrome://browser/content/preferences/cookies.xhtml) {
   #CookiesDialog {
     -moz-appearance: none!important;
     background-color: var(--in-content-page-background)!important


### PR DESCRIPTION
Replaces references to .xul with .xhtml to fix problems caused by Mozilla's deprecation of XUL.

Fixes issue #307 